### PR TITLE
Add potential to parse string sequences into includes 

### DIFF
--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -102,10 +102,12 @@ func (c *Crawler) updateProjectInGraph(ctx context.Context, project gitlab.Proje
 			return fmt.Errorf("failed to get file %s: %w", gitlabCIFileName, err)
 		}
 
-		includes, err := c.parseIncludes(gitlabCIFile, project)
+		includes, err := c.parseIncludes(gitlabCIFile)
 		if err != nil {
 			return fmt.Errorf("failed to parse includes for %d: %w", project.ID, err)
 		}
+
+		includes = enrichIncludes(includes, project)
 
 		for _, i := range includes {
 			if i.Ref == "" {


### PR DESCRIPTION
This does complicate the parsing logic a bit, but it seems better
than jumping into reflect and overwriting the YAML parser, it's
simpler and more maintainable in the long run.

Mixed cases are ignored for now since that would almost require
reflection and custom parsers. I feel this catches most of the
common problems that I have experienced for now. I'd rather not
add a component that I am not very familiar or comfortable with
to the architecture at this point.