### PR TITLE
Add DefaultRefName config option to the crawler

### DIFF
--- a/internal/crawler/config.go
+++ b/internal/crawler/config.go
@@ -32,10 +32,11 @@ func StorageFromString(s string) (Storage, error) {
 }
 
 type Config struct {
-	GitlabHost   string `conf:"required,short:g,env:GITLAB_HOST"`
-	GitlabToken  string `conf:"required,short:t,env:GITLAB_TOKEN"`
-	GitlabMaxRPS int    `conf:"default:1,short:r,env:GITLAB_MAX_RPS"`
-	Storage      string `conf:"required,short:s,env:STORAGE_BACKEND"`
+	GitlabHost     string `conf:"required,short:g,env:GITLAB_HOST"`
+	GitlabToken    string `conf:"required,short:t,env:GITLAB_TOKEN"`
+	GitlabMaxRPS   int    `conf:"default:1,short:r,env:GITLAB_MAX_RPS"`
+	Storage        string `conf:"required,short:s,env:STORAGE_BACKEND"`
+	DefaultRefName string `conf:"default:HEAD,short:d,env:DEFAULT_REF_NAME"`
 }
 
 func ParseConfig(cfg *Config) error {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -107,7 +107,7 @@ func (c *Crawler) updateProjectInGraph(ctx context.Context, project gitlab.Proje
 			return fmt.Errorf("failed to parse includes for %d: %w", project.ID, err)
 		}
 
-		includes = enrichIncludes(includes, project)
+		includes = enrichIncludes(includes, project, c.config.DefaultRefName)
 
 		for _, i := range includes {
 			if i.Ref == "" {

--- a/internal/crawler/template.go
+++ b/internal/crawler/template.go
@@ -72,16 +72,15 @@ func (c *Crawler) parseIncludes(file []byte) ([]RemoteInclude, error) {
 	return nil, fmt.Errorf("parsing error: %s", strings.Join(errorList, ","))
 }
 
-func enrichIncludes(rawIncludes []RemoteInclude, project gitlab.Project) []RemoteInclude {
+func enrichIncludes(rawIncludes []RemoteInclude, project gitlab.Project, defaultRefName string) []RemoteInclude {
 	enrichedIncludes := make([]RemoteInclude, len(rawIncludes))
 
 	for i, include := range rawIncludes {
 		switch {
 		case include.Project != "":
 			if include.Ref == "" {
-				log.Printf("setting ref for %s:%s to `main` because no ref was specified", include.Project, strings.Join(include.Files, ","))
-				include.Ref = "main" // this is not really right but less ambiguous than `""`
-
+				log.Printf("setting ref for %s:%s to `%s` because no ref was specified", include.Project, strings.Join(include.Files, ","), defaultRefName)
+				include.Ref = defaultRefName
 			}
 		case include.Local != "":
 			include.Project = project.PathWithNamespace


### PR DESCRIPTION
This controls what empty refs are set to, the default reflects
what GitLab is doing actually: https://docs.gitlab.com/ee/ci/yaml/#includefile

> You can also specify a ref. If you do not specify a value, the ref defaults to the HEAD of the project

At this point I don't want to make more calls against the GitLab API
to fetch the current HEAD of each project - but that might be changed
later on. This crawler does make a decent amount of calls as it is
no need to make more for a value that's dynamic and changing constantly
anyway.